### PR TITLE
Fix: local login

### DIFF
--- a/config/publisher.yml
+++ b/config/publisher.yml
@@ -7,7 +7,7 @@ host_to_automatic_api_host:
   - ".malibu"
 domain_mapping:
   subdomain.lvh.me: subdomain
-
+  malibu.lvh.me: localhost:3000
 publisher:
   timezone: "Asia/Baku"
   google_tag_manager:


### PR DESCRIPTION
# Description

we have noticed the login not working on the local machine. When we debugged the issue we got to know the FB and google login does not support localhost:3000 as redirect URL

Fixes: https://github.com/quintype/ace-planning/issues/427

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
