### PR TITLE
Visual stories

### DIFF
--- a/app/isomorphic/constants.js
+++ b/app/isomorphic/constants.js
@@ -14,7 +14,8 @@ export const PAGE_TYPE = Object.freeze({
   AUTHOR_PAGE: "author-page",
   RESET_PASSWORD_PAGE: "reset-password-page",
   PROFILE_PAGE: "profile-page",
-  USER_LOGIN: "user-login"
+  USER_LOGIN: "user-login",
+  VISUAL_STORY: "visual-story"
 });
 export const TAG_PAGE_URL_PREFIX = "/topic/";
 export const storyFields =

--- a/app/server/routes.js
+++ b/app/server/routes.js
@@ -21,6 +21,11 @@ export const STATIC_ROUTES = [
     exact: true,
     renderParams: { contentTemplate: "./story-preview" },
     disableIsomorphicComponent: false
+  },
+  {
+    path: "/ampstories/*",
+    pageType: PAGE_TYPE.VISUAL_STORY,
+    exact: true
   }
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4679,9 +4679,9 @@
       }
     },
     "@quintype/framework": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-6.3.0.tgz",
-      "integrity": "sha512-Ul7B5fMiwJHN5HIraLFVrQCW11YU341zCmZLMJevgTvQ9Uv4RedNemAIbQMXnCxGNswEGcFV4SeeRVLP192SDg==",
+      "version": "6.3.1-amp-infinite-scroll-bugfix.0",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-6.3.1-amp-infinite-scroll-bugfix.0.tgz",
+      "integrity": "sha512-5J1b6c9qovehahRhZ9iAYD4220QCJKLE6UsCLeqyUd+6cUOrs+xJocPcReT5k/H/KRsl+sSJ4eDt21rYuSTp4w==",
       "requires": {
         "@ampproject/toolbox-optimizer": "2.8.0",
         "@quintype/amp": "^2.4.15",
@@ -6258,12 +6258,12 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.3.tgz",
-      "integrity": "sha512-meGStRGv+VuKA/q0/jXxrPNWEm4LPfYIqxooDTdmh8kFsP/Ph7jJG5rUPwUPX3QHUvggwdbgdGpo88P/rRYsVw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.1.tgz",
+      "integrity": "sha512-U3wmORxerYBiqcRCo6thItIosEIga3F+ph0jJPkiOZJjyhpZyUZFQV9XvrZ2CbBIihJ3rDBC/itQ+Wx3VHMauw==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.15.4",
-        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "lodash": "^4.17.11"
       },
@@ -31036,9 +31036,9 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         },
         "source-map-support": {
-          "version": "0.5.20",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-          "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4679,9 +4679,9 @@
       }
     },
     "@quintype/framework": {
-      "version": "6.3.1-amp-infinite-scroll-bugfix.0",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-6.3.1-amp-infinite-scroll-bugfix.0.tgz",
-      "integrity": "sha512-5J1b6c9qovehahRhZ9iAYD4220QCJKLE6UsCLeqyUd+6cUOrs+xJocPcReT5k/H/KRsl+sSJ4eDt21rYuSTp4w==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-6.3.1.tgz",
+      "integrity": "sha512-Y1JXcfEyV5uINw9nuDqjW3HiMv+ZXPt2hgK64bhTrUPfTxGSFu6FdShRM0lgStllV8h0WzM2FTN6maIRBkpyvw==",
       "requires": {
         "@ampproject/toolbox-optimizer": "2.8.0",
         "@quintype/amp": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@quintype/arrow": "^2.9.9",
     "@quintype/bridgekeeper-js": "^2.8.1",
     "@quintype/components": "^2.31.7",
-    "@quintype/framework": "^6.3.0",
+    "@quintype/framework": "^6.3.1-amp-infinite-scroll-bugfix.0",
     "@quintype/seo": "^1.38.39",
     "fontfaceobserver": "^2.1.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@quintype/arrow": "^2.9.9",
     "@quintype/bridgekeeper-js": "^2.8.1",
     "@quintype/components": "^2.31.7",
-    "@quintype/framework": "^6.3.1-amp-infinite-scroll-bugfix.0",
+    "@quintype/framework": "^6.3.1",
     "@quintype/seo": "^1.38.39",
     "fontfaceobserver": "^2.1.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
- add routing needed for AMP visual stories: https://developers.quintype.com/quintype-amp/tutorial-visual-stories.html
- bump framework to fix [this](https://github.com/quintype/ace-planning/issues/584) issue