### PR TITLE
Add. navbarRender render prop and beta of framework to support Custom Navbar 

### DIFF
--- a/app/server/app.js
+++ b/app/server/app.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console, no-unused-vars, import/extensions, object-shorthand, global-require */
+import React from "react";
 import createApp from "@quintype/framework/server/create-app";
 import { getClient, Collection } from "@quintype/framework/server/api-client";
 import logger from "@quintype/framework/server/logger";
@@ -91,6 +92,9 @@ function generateSeo(config, pageType) {
 
 ampRoutes(app, {
   seo: generateSeo,
+  render: {
+    navbarRender: ({config, theme }) => <h3>Custom Navbar</h3>
+  },
 });
 
 isomorphicRoutes(app, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@loadable/server": "^5.14.2",
         "@quintype/bridgekeeper-js": "^2.8.2-feature-otp.1",
         "@quintype/components": "^3.0.2",
-        "@quintype/framework": "^7.7.7",
+        "@quintype/framework": "7.19.4-searc-on-header.0",
         "@quintype/seo": "^1.42.1",
         "axios": "^0.24.0",
         "fontfaceobserver": "^2.1.0",
@@ -532,18 +532,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-define-map": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.18.6.tgz",
-      "integrity": "sha512-XSOjXUDG7KODvtURN1p29hGHa4RFgqBQELuBowUOBt3alf2Ny/oNFJygS4yCXwM0vMoqLDjE1O7wSmocUmQ3Kg==",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.18.6",
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
@@ -763,9 +751,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2068,12 +2056,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-mutators": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.18.6.tgz",
-      "integrity": "sha512-30BjBu2xyai0GivUBMeFmHlFxeZtJXHcTUUrRRIZ9u0Mihk0qzREWicLUjDO/hcQOfya1I0pQ7eAcKKNt0BKug==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.20.7.tgz",
+      "integrity": "sha512-Jq14o707UCRcGrdWa3qyA9TMoa/dMi9GfrphmwsppuZ3jxbDqRXHrQkjLN87sopIV3Zlp8SRZS48+S9ABcmC7g==",
       "dependencies": {
-        "@babel/helper-define-map": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2626,17 +2613,17 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -5017,12 +5004,12 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.28.tgz",
-      "integrity": "sha512-LAta0Bt8fthHxORK1232kTrp516ZAJCR9ixqNmvj911bi7cP6It9eDesCDO+O4jP8rcVDqROc1ns/MZwDFGeyg==",
+      "version": "2.12.0-search-on-header.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.0.tgz",
+      "integrity": "sha512-CSvh3a5XUpgKD8KcAMVl+Fn0dWz+UVonyn0XREOF07azVC4u0I5sE49+kpQhJfMtZRgYTaOjlYpoXQJeTFCyaA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
-        "atob": "^2.1.2",
+        "atob-utf-8": "^1.0.4",
         "babel-preset-airbnb": "^5.0.0",
         "date-fns": "^2.11.0",
         "date-fns-tz": "^1.0.10",
@@ -5043,9 +5030,9 @@
       }
     },
     "node_modules/@quintype/backend": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.1.tgz",
-      "integrity": "sha512-z6DVASwl+TwmTtrjqJ3G9fzakpjQaFiN74inKornAgHYlJgqP5+irgEUnmwCVg8a4UCCcWqAJams4bkA7qu2kQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.3.tgz",
+      "integrity": "sha512-tpzH5gzBvPDCK03yX0uZoHF5s/ZX6JehW9Y+xA2O0bMX88kRPtB2weu/tv7sp+vuaoU/SjgK6owHNDC/EQcXZw==",
       "dependencies": {
         "axios": "^0.21.1",
         "bluebird": "^3.7.2",
@@ -5060,25 +5047,6 @@
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@quintype/backend/node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/@quintype/bridgekeeper-js": {
@@ -5327,12 +5295,11 @@
       }
     },
     "node_modules/@quintype/components": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.0.2.tgz",
-      "integrity": "sha512-QhfDexSof8oU3yenG9m4SB9qKuph/qKTtz7a2dDroPDKecul/Ig/jrwRNiOpZd/Mcicwyhb2LMigIoaJf0OmWw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.3.2.tgz",
+      "integrity": "sha512-SK73TjiFAis2/xDERhqcI6OuC2O6j47R05sh43zfL+j6Q/WHam0fsIc7H38FPF0/VDucfEeurpUV355qznTUCQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.3",
-        "atob": "^2.1.2",
         "classnames": "^2.3.1",
         "empty-web-gif": "^1.0.1",
         "get-video-id": "^3.4.3",
@@ -5377,14 +5344,14 @@
       "integrity": "sha512-N2sYGNRaianJZJROz31vNoGo7Sd+2ElX9g+qwiOQ8/+3oJVCEOkFxVMSYT/8QQqTrWs5bmMbDyxrOleALhUMCA=="
     },
     "node_modules/@quintype/framework": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.7.7.tgz",
-      "integrity": "sha512-FGIkT2PVdJBR5UbarU97kArIZBfOMUiHugELGscxM6R3yzUrP0wEzzLmqhu9caWWJ2ZD/ThFaE2E3dUhRYViXQ==",
+      "version": "7.19.4-searc-on-header.0",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.4-searc-on-header.0.tgz",
+      "integrity": "sha512-TIWJ0/XbKeXRtlzq+ahS7UIenE8EXgPwQqsLc/zn1ieAyPLN+BZPuvcnzxMZfTeW+nUqKG36zceVpJck5LcQZA==",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.4.28",
-        "@quintype/backend": "^2.3.1",
-        "@quintype/components": "^3.0.0",
+        "@quintype/amp": "2.12.0-search-on-header.0",
+        "@quintype/backend": "^2.3.3",
+        "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
         "@quintype/seo": "^1.39.0",
         "atob": "^2.1.2",
@@ -7133,6 +7100,17 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/atob-utf-8": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/atob-utf-8/-/atob-utf-8-1.0.4.tgz",
+      "integrity": "sha512-URuOY6Qtmeu51HqXgIO/osI2MAY6kiJ5WwXMo3hqTlaGn28AexlyPvJFy5fsfcpc3EgnglbaHkkDZ5ibFKWLww==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/autocompleter": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.2.tgz",
@@ -7210,25 +7188,6 @@
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
         "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/babel-code-frame": {
@@ -7617,14 +7576,14 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz",
+      "integrity": "sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "picomatch": "^2.3.0"
       },
       "peerDependencies": {
@@ -8602,9 +8561,12 @@
       }
     },
     "node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
@@ -10040,9 +10002,9 @@
       }
     },
     "node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -13392,22 +13354,22 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/follow-redirects/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -27727,7 +27689,7 @@
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28164,10 +28126,9 @@
       "dev": true
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "hasInstallScript": true,
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.10.tgz",
+      "integrity": "sha512-3kSzSBN0TiCnGJM04UwO1HklIQQSXW7rCARUk+VyMR7clz8XVlA3jijtf5ypqoDIdNMKx3la4VvaPFR855SFcg==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -33149,15 +33110,6 @@
         "regexpu-core": "^4.7.1"
       }
     },
-    "@babel/helper-define-map": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.18.6.tgz",
-      "integrity": "sha512-XSOjXUDG7KODvtURN1p29hGHa4RFgqBQELuBowUOBt3alf2Ny/oNFJygS4yCXwM0vMoqLDjE1O7wSmocUmQ3Kg==",
-      "requires": {
-        "@babel/helper-function-name": "^7.18.6",
-        "@babel/types": "^7.18.6"
-      }
-    },
     "@babel/helper-define-polyfill-provider": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
@@ -33320,9 +33272,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg=="
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.16.4",
@@ -34184,12 +34136,11 @@
       }
     },
     "@babel/plugin-transform-property-mutators": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.18.6.tgz",
-      "integrity": "sha512-30BjBu2xyai0GivUBMeFmHlFxeZtJXHcTUUrRRIZ9u0Mihk0qzREWicLUjDO/hcQOfya1I0pQ7eAcKKNt0BKug==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.20.7.tgz",
+      "integrity": "sha512-Jq14o707UCRcGrdWa3qyA9TMoa/dMi9GfrphmwsppuZ3jxbDqRXHrQkjLN87sopIV3Zlp8SRZS48+S9ABcmC7g==",
       "requires": {
-        "@babel/helper-define-map": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -34589,17 +34540,17 @@
       "dev": true
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
@@ -36525,12 +36476,12 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.28.tgz",
-      "integrity": "sha512-LAta0Bt8fthHxORK1232kTrp516ZAJCR9ixqNmvj911bi7cP6It9eDesCDO+O4jP8rcVDqROc1ns/MZwDFGeyg==",
+      "version": "2.12.0-search-on-header.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.12.0-search-on-header.0.tgz",
+      "integrity": "sha512-CSvh3a5XUpgKD8KcAMVl+Fn0dWz+UVonyn0XREOF07azVC4u0I5sE49+kpQhJfMtZRgYTaOjlYpoXQJeTFCyaA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
-        "atob": "^2.1.2",
+        "atob-utf-8": "^1.0.4",
         "babel-preset-airbnb": "^5.0.0",
         "date-fns": "^2.11.0",
         "date-fns-tz": "^1.0.10",
@@ -36547,9 +36498,9 @@
       }
     },
     "@quintype/backend": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.1.tgz",
-      "integrity": "sha512-z6DVASwl+TwmTtrjqJ3G9fzakpjQaFiN74inKornAgHYlJgqP5+irgEUnmwCVg8a4UCCcWqAJams4bkA7qu2kQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.3.tgz",
+      "integrity": "sha512-tpzH5gzBvPDCK03yX0uZoHF5s/ZX6JehW9Y+xA2O0bMX88kRPtB2weu/tv7sp+vuaoU/SjgK6owHNDC/EQcXZw==",
       "requires": {
         "axios": "^0.21.1",
         "bluebird": "^3.7.2",
@@ -36565,11 +36516,6 @@
           "requires": {
             "follow-redirects": "^1.14.0"
           }
-        },
-        "follow-redirects": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-          "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
         }
       }
     },
@@ -36760,12 +36706,11 @@
       }
     },
     "@quintype/components": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.0.2.tgz",
-      "integrity": "sha512-QhfDexSof8oU3yenG9m4SB9qKuph/qKTtz7a2dDroPDKecul/Ig/jrwRNiOpZd/Mcicwyhb2LMigIoaJf0OmWw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.3.2.tgz",
+      "integrity": "sha512-SK73TjiFAis2/xDERhqcI6OuC2O6j47R05sh43zfL+j6Q/WHam0fsIc7H38FPF0/VDucfEeurpUV355qznTUCQ==",
       "requires": {
         "@babel/runtime": "^7.16.3",
-        "atob": "^2.1.2",
         "classnames": "^2.3.1",
         "empty-web-gif": "^1.0.1",
         "get-video-id": "^3.4.3",
@@ -36806,14 +36751,14 @@
       }
     },
     "@quintype/framework": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.7.7.tgz",
-      "integrity": "sha512-FGIkT2PVdJBR5UbarU97kArIZBfOMUiHugELGscxM6R3yzUrP0wEzzLmqhu9caWWJ2ZD/ThFaE2E3dUhRYViXQ==",
+      "version": "7.19.4-searc-on-header.0",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.4-searc-on-header.0.tgz",
+      "integrity": "sha512-TIWJ0/XbKeXRtlzq+ahS7UIenE8EXgPwQqsLc/zn1ieAyPLN+BZPuvcnzxMZfTeW+nUqKG36zceVpJck5LcQZA==",
       "requires": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.4.28",
-        "@quintype/backend": "^2.3.1",
-        "@quintype/components": "^3.0.0",
+        "@quintype/amp": "2.12.0-search-on-header.0",
+        "@quintype/backend": "^2.3.3",
+        "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
         "@quintype/seo": "^1.39.0",
         "atob": "^2.1.2",
@@ -38246,6 +38191,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "atob-utf-8": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/atob-utf-8/-/atob-utf-8-1.0.4.tgz",
+      "integrity": "sha512-URuOY6Qtmeu51HqXgIO/osI2MAY6kiJ5WwXMo3hqTlaGn28AexlyPvJFy5fsfcpc3EgnglbaHkkDZ5ibFKWLww=="
+    },
     "autocompleter": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.2.tgz",
@@ -38300,13 +38250,6 @@
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
         "follow-redirects": "^1.14.4"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.14.5",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
-        }
       }
     },
     "babel-code-frame": {
@@ -38622,14 +38565,14 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.1.tgz",
+      "integrity": "sha512-c8lJlszObVQPguHkI+akXv8+Jgb9Ccujx0EetL7oIvwU100LxO6XAGe45qry37wUL40a5U9f23SYrivro2XKhA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "picomatch": "^2.3.0"
       }
     },
@@ -39451,9 +39394,9 @@
       }
     },
     "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -40605,9 +40548,9 @@
       }
     },
     "css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -43212,22 +43155,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fontfaceobserver": {
       "version": "2.1.0",
@@ -54264,7 +54194,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -54608,9 +54538,9 @@
       "dev": true
     },
     "styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.10.tgz",
+      "integrity": "sha512-3kSzSBN0TiCnGJM04UwO1HklIQQSXW7rCARUk+VyMR7clz8XVlA3jijtf5ypqoDIdNMKx3la4VvaPFR855SFcg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@loadable/server": "^5.14.2",
     "@quintype/bridgekeeper-js": "^2.8.2-feature-otp.1",
     "@quintype/components": "^3.0.2",
-    "@quintype/framework": "^7.7.7",
+    "@quintype/framework": "7.19.4-searc-on-header.0",
     "@quintype/seo": "^1.42.1",
     "axios": "^0.24.0",
     "fontfaceobserver": "^2.1.0",


### PR DESCRIPTION

# Description
Provide an option to pass custom Navbar through FE;
we have search page on the header for normal pages which directs the user to the search page. 
The client (praja vani) wants the same to be replicated for AMP as well .

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/841#event-9196522028

Dependencies # (dependency-issue-reference)
https://github.com/quintype/quintype-amp/pull/433
https://github.com/quintype/quintype-node-framework/pull/369

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
