### PR TITLE
fix: hide author, timestamp when those attributes are enabled

### DIFF
--- a/app/isomorphic/arrow/components/Rows/FourTabbedBigStorySlider/index.js
+++ b/app/isomorphic/arrow/components/Rows/FourTabbedBigStorySlider/index.js
@@ -116,7 +116,7 @@ export const FourTabbedBigStorySlider = ({ collection, config = {} }) => {
   );
 };
 
-const DefaultStoryCardContent = ({ story, config = {}, borderColor, showSubheadline }) => {
+const DefaultStoryCardContentBase = ({ story, config = {}, borderColor, showSubheadline }) => {
   const SectionTagborderColor = rgbToHex(borderColor);
   const { localizationConfig = {} } = config;
   return (
@@ -138,6 +138,7 @@ const DefaultStoryCardContent = ({ story, config = {}, borderColor, showSubheadl
 };
 
 export default StateProvider(FourTabbedBigStorySlider);
+const DefaultStoryCardContent = StateProvider(DefaultStoryCardContentBase);
 
 FourTabbedBigStorySlider.propTypes = {
   /**  collection is the array of objects which is returning by API  */
@@ -153,7 +154,7 @@ FourTabbedBigStorySlider.propTypes = {
   }),
 };
 
-DefaultStoryCardContent.propTypes = {
+DefaultStoryCardContentBase.propTypes = {
   story: PropTypes.object.isRequired,
   config: PropTypes.object,
   borderColor: PropTypes.string,


### PR DESCRIPTION
Reference: https://github.com/quintype/ace-planning/issues/844