### PR TITLE
Focus point not set on HeroImage in Amp stories 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@loadable/server": "^5.14.2",
         "@quintype/bridgekeeper-js": "^2.8.2-feature-otp.1",
         "@quintype/components": "^3.0.2",
-        "@quintype/framework": "^7.19.9-amp-focus-point.2",
+        "@quintype/framework": "^7.19.11",
         "@quintype/seo": "^1.42.1",
         "axios": "^0.24.0",
         "fontfaceobserver": "^2.1.0",
@@ -1567,11 +1567,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz",
-      "integrity": "sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -5013,9 +5013,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.14.1-amp-focus-point.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.1-amp-focus-point.0.tgz",
-      "integrity": "sha512-ScrpObc/Wy3ynvk8rLEl5FMzLiiuEW3lOrijE7wBrjxmX4fFEZ+ewq1wr0uzzrri2+rzUk5ePaaRAS8xmRMXEg==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.1.tgz",
+      "integrity": "sha512-vhW+EZIFB9S+VJNHo9UvcemaXv5ze9cS+z+SYj14408IlQFTpy0tG6djk56v4Q16Vd+q7EKEDgzEDkDvwm0wfA==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -5353,12 +5353,12 @@
       "integrity": "sha512-N2sYGNRaianJZJROz31vNoGo7Sd+2ElX9g+qwiOQ8/+3oJVCEOkFxVMSYT/8QQqTrWs5bmMbDyxrOleALhUMCA=="
     },
     "node_modules/@quintype/framework": {
-      "version": "7.19.9-amp-focus-point.2",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.9-amp-focus-point.2.tgz",
-      "integrity": "sha512-++CFanAA9jH5LLAQt6LBvHkuhY58JbJMq62jIL7MvEIzCjCanRoAhUKwOypNvn0AfJmYYznCjxm8gHhoI8mbzg==",
+      "version": "7.19.11",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.11.tgz",
+      "integrity": "sha512-zPxQ7RQ4gUCEWVai6Q3h5dxUhwotjvqb/MPxdgUyE9fw2YD3c7FQLxQ1OhVUNS3OVw0Ic/clmnU/PpM/iKnPLA==",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.14.1-amp-focus-point.0",
+        "@quintype/amp": "^2.15.2",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -7585,24 +7585,19 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.3.tgz",
-      "integrity": "sha512-jBioLwBVHpOMU4NsueH/ADcHrjS0Y/WTpt2eGVmmuSFNEv2DF3XhcMncuZlbbjxQ4vzxg+yEr6E6TNjrIQbsJQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.21.4",
-        "babel-plugin-syntax-jsx": "^6.18.0",
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
         "lodash": "^4.17.21",
         "picomatch": "^2.3.1"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
       }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "node_modules/babel-plugin-transform-assets-import-to-string": {
       "version": "1.2.0",
@@ -33838,11 +33833,11 @@
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz",
-      "integrity": "sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -36491,9 +36486,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.14.1-amp-focus-point.0",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.1-amp-focus-point.0.tgz",
-      "integrity": "sha512-ScrpObc/Wy3ynvk8rLEl5FMzLiiuEW3lOrijE7wBrjxmX4fFEZ+ewq1wr0uzzrri2+rzUk5ePaaRAS8xmRMXEg==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.17.1.tgz",
+      "integrity": "sha512-vhW+EZIFB9S+VJNHo9UvcemaXv5ze9cS+z+SYj14408IlQFTpy0tG6djk56v4Q16Vd+q7EKEDgzEDkDvwm0wfA==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
         "atob-utf-8": "^1.0.4",
@@ -36766,12 +36761,12 @@
       }
     },
     "@quintype/framework": {
-      "version": "7.19.9-amp-focus-point.2",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.9-amp-focus-point.2.tgz",
-      "integrity": "sha512-++CFanAA9jH5LLAQt6LBvHkuhY58JbJMq62jIL7MvEIzCjCanRoAhUKwOypNvn0AfJmYYznCjxm8gHhoI8mbzg==",
+      "version": "7.19.11",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.11.tgz",
+      "integrity": "sha512-zPxQ7RQ4gUCEWVai6Q3h5dxUhwotjvqb/MPxdgUyE9fw2YD3c7FQLxQ1OhVUNS3OVw0Ic/clmnU/PpM/iKnPLA==",
       "requires": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.14.1-amp-focus-point.0",
+        "@quintype/amp": "^2.15.2",
         "@quintype/backend": "^2.3.3",
         "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
@@ -38580,21 +38575,16 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.3.tgz",
-      "integrity": "sha512-jBioLwBVHpOMU4NsueH/ADcHrjS0Y/WTpt2eGVmmuSFNEv2DF3XhcMncuZlbbjxQ4vzxg+yEr6E6TNjrIQbsJQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-module-imports": "^7.21.4",
-        "babel-plugin-syntax-jsx": "^6.18.0",
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
         "lodash": "^4.17.21",
         "picomatch": "^2.3.1"
       }
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "babel-plugin-transform-assets-import-to-string": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@loadable/server": "^5.14.2",
         "@quintype/bridgekeeper-js": "^2.8.2-feature-otp.1",
         "@quintype/components": "^3.0.2",
-        "@quintype/framework": "^7.7.7",
+        "@quintype/framework": "^7.19.9-amp-focus-point.2",
         "@quintype/seo": "^1.42.1",
         "axios": "^0.24.0",
         "fontfaceobserver": "^2.1.0",
@@ -448,11 +448,11 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
-      "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -530,18 +530,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-define-map": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.18.6.tgz",
-      "integrity": "sha512-XSOjXUDG7KODvtURN1p29hGHa4RFgqBQELuBowUOBt3alf2Ny/oNFJygS4yCXwM0vMoqLDjE1O7wSmocUmQ3Kg==",
-      "dependencies": {
-        "@babel/helper-function-name": "^7.18.6",
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -629,11 +617,11 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -763,9 +751,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -924,10 +912,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2068,12 +2064,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-mutators": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.18.6.tgz",
-      "integrity": "sha512-30BjBu2xyai0GivUBMeFmHlFxeZtJXHcTUUrRRIZ9u0Mihk0qzREWicLUjDO/hcQOfya1I0pQ7eAcKKNt0BKug==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.22.5.tgz",
+      "integrity": "sha512-rb+Qamlhsa8wghtCXFeLTXmAeczJXwJqUXTXxXIco1QOki2R1UiHESXAF6Jl54penxA5DjutstmIraQO1vyDwA==",
       "dependencies": {
-        "@babel/helper-define-map": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2563,11 +2558,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/@babel/types": {
-      "version": "7.18.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.8.tgz",
-      "integrity": "sha512-qwpdsmraq0aJ3osLJRApsc2ouSJCdnMeZwB0DhbtHAtRpZNZCdlbRnHIgcRKzdE1g0iOGg644fzjOBcdOz9cPw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -2626,17 +2622,17 @@
       }
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -5017,12 +5013,12 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@quintype/amp": {
-      "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.28.tgz",
-      "integrity": "sha512-LAta0Bt8fthHxORK1232kTrp516ZAJCR9ixqNmvj911bi7cP6It9eDesCDO+O4jP8rcVDqROc1ns/MZwDFGeyg==",
+      "version": "2.14.1-amp-focus-point.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.1-amp-focus-point.0.tgz",
+      "integrity": "sha512-ScrpObc/Wy3ynvk8rLEl5FMzLiiuEW3lOrijE7wBrjxmX4fFEZ+ewq1wr0uzzrri2+rzUk5ePaaRAS8xmRMXEg==",
       "dependencies": {
         "@rvgpl/get-youtube-id": "^1.0.0",
-        "atob": "^2.1.2",
+        "atob-utf-8": "^1.0.4",
         "babel-preset-airbnb": "^5.0.0",
         "date-fns": "^2.11.0",
         "date-fns-tz": "^1.0.10",
@@ -5043,9 +5039,9 @@
       }
     },
     "node_modules/@quintype/backend": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.1.tgz",
-      "integrity": "sha512-z6DVASwl+TwmTtrjqJ3G9fzakpjQaFiN74inKornAgHYlJgqP5+irgEUnmwCVg8a4UCCcWqAJams4bkA7qu2kQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.3.tgz",
+      "integrity": "sha512-tpzH5gzBvPDCK03yX0uZoHF5s/ZX6JehW9Y+xA2O0bMX88kRPtB2weu/tv7sp+vuaoU/SjgK6owHNDC/EQcXZw==",
       "dependencies": {
         "axios": "^0.21.1",
         "bluebird": "^3.7.2",
@@ -5060,25 +5056,6 @@
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@quintype/backend/node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/@quintype/bridgekeeper-js": {
@@ -5327,12 +5304,11 @@
       }
     },
     "node_modules/@quintype/components": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.0.2.tgz",
-      "integrity": "sha512-QhfDexSof8oU3yenG9m4SB9qKuph/qKTtz7a2dDroPDKecul/Ig/jrwRNiOpZd/Mcicwyhb2LMigIoaJf0OmWw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.3.3.tgz",
+      "integrity": "sha512-a1XfNBICVtPq1h3ATr37asjeF/jI2j+rwhtrw5uV+YBSH9dXjZ3L/WjH+/T066Dt+EgfGjUkczXUwdRF6YBxmA==",
       "dependencies": {
         "@babel/runtime": "^7.16.3",
-        "atob": "^2.1.2",
         "classnames": "^2.3.1",
         "empty-web-gif": "^1.0.1",
         "get-video-id": "^3.4.3",
@@ -5377,14 +5353,14 @@
       "integrity": "sha512-N2sYGNRaianJZJROz31vNoGo7Sd+2ElX9g+qwiOQ8/+3oJVCEOkFxVMSYT/8QQqTrWs5bmMbDyxrOleALhUMCA=="
     },
     "node_modules/@quintype/framework": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.7.7.tgz",
-      "integrity": "sha512-FGIkT2PVdJBR5UbarU97kArIZBfOMUiHugELGscxM6R3yzUrP0wEzzLmqhu9caWWJ2ZD/ThFaE2E3dUhRYViXQ==",
+      "version": "7.19.9-amp-focus-point.2",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.9-amp-focus-point.2.tgz",
+      "integrity": "sha512-++CFanAA9jH5LLAQt6LBvHkuhY58JbJMq62jIL7MvEIzCjCanRoAhUKwOypNvn0AfJmYYznCjxm8gHhoI8mbzg==",
       "dependencies": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.4.28",
-        "@quintype/backend": "^2.3.1",
-        "@quintype/components": "^3.0.0",
+        "@quintype/amp": "^2.14.1-amp-focus-point.0",
+        "@quintype/backend": "^2.3.3",
+        "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
         "@quintype/seo": "^1.39.0",
         "atob": "^2.1.2",
@@ -7133,6 +7109,17 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/atob-utf-8": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/atob-utf-8/-/atob-utf-8-1.0.4.tgz",
+      "integrity": "sha512-URuOY6Qtmeu51HqXgIO/osI2MAY6kiJ5WwXMo3hqTlaGn28AexlyPvJFy5fsfcpc3EgnglbaHkkDZ5ibFKWLww==",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/autocompleter": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.2.tgz",
@@ -7210,25 +7197,6 @@
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
         "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/babel-code-frame": {
@@ -7617,15 +7585,15 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.3.tgz",
+      "integrity": "sha512-jBioLwBVHpOMU4NsueH/ADcHrjS0Y/WTpt2eGVmmuSFNEv2DF3XhcMncuZlbbjxQ4vzxg+yEr6E6TNjrIQbsJQ==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.21.4",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
@@ -8602,9 +8570,12 @@
       }
     },
     "node_modules/camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
@@ -10040,9 +10011,9 @@
       }
     },
     "node_modules/css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -13392,22 +13363,22 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dependencies": {
-        "debug": "=3.1.0"
-      },
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/follow-redirects/node_modules/debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dependencies": {
-        "ms": "2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fontfaceobserver": {
@@ -21958,9 +21929,9 @@
       "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -27727,7 +27698,7 @@
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28164,10 +28135,9 @@
       "dev": true
     },
     "node_modules/styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
-      "hasInstallScript": true,
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -33090,11 +33060,11 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
-      "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -33147,15 +33117,6 @@
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "regexpu-core": "^4.7.1"
-      }
-    },
-    "@babel/helper-define-map": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.18.6.tgz",
-      "integrity": "sha512-XSOjXUDG7KODvtURN1p29hGHa4RFgqBQELuBowUOBt3alf2Ny/oNFJygS4yCXwM0vMoqLDjE1O7wSmocUmQ3Kg==",
-      "requires": {
-        "@babel/helper-function-name": "^7.18.6",
-        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-define-polyfill-provider": {
@@ -33222,11 +33183,11 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
+      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-module-transforms": {
@@ -33320,9 +33281,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg=="
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.16.4",
@@ -33436,10 +33397,15 @@
         "@babel/types": "^7.14.5"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
     },
     "@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -34184,12 +34150,11 @@
       }
     },
     "@babel/plugin-transform-property-mutators": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.18.6.tgz",
-      "integrity": "sha512-30BjBu2xyai0GivUBMeFmHlFxeZtJXHcTUUrRRIZ9u0Mihk0qzREWicLUjDO/hcQOfya1I0pQ7eAcKKNt0BKug==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-mutators/-/plugin-transform-property-mutators-7.22.5.tgz",
+      "integrity": "sha512-rb+Qamlhsa8wghtCXFeLTXmAeczJXwJqUXTXxXIco1QOki2R1UiHESXAF6Jl54penxA5DjutstmIraQO1vyDwA==",
       "requires": {
-        "@babel/helper-define-map": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.22.5"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -34539,11 +34504,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.18.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.8.tgz",
-      "integrity": "sha512-qwpdsmraq0aJ3osLJRApsc2ouSJCdnMeZwB0DhbtHAtRpZNZCdlbRnHIgcRKzdE1g0iOGg644fzjOBcdOz9cPw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
+      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -34589,17 +34555,17 @@
       "dev": true
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "@emotion/stylis": {
       "version": "0.8.5",
@@ -36525,12 +36491,12 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@quintype/amp": {
-      "version": "2.4.28",
-      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.4.28.tgz",
-      "integrity": "sha512-LAta0Bt8fthHxORK1232kTrp516ZAJCR9ixqNmvj911bi7cP6It9eDesCDO+O4jP8rcVDqROc1ns/MZwDFGeyg==",
+      "version": "2.14.1-amp-focus-point.0",
+      "resolved": "https://registry.npmjs.org/@quintype/amp/-/amp-2.14.1-amp-focus-point.0.tgz",
+      "integrity": "sha512-ScrpObc/Wy3ynvk8rLEl5FMzLiiuEW3lOrijE7wBrjxmX4fFEZ+ewq1wr0uzzrri2+rzUk5ePaaRAS8xmRMXEg==",
       "requires": {
         "@rvgpl/get-youtube-id": "^1.0.0",
-        "atob": "^2.1.2",
+        "atob-utf-8": "^1.0.4",
         "babel-preset-airbnb": "^5.0.0",
         "date-fns": "^2.11.0",
         "date-fns-tz": "^1.0.10",
@@ -36547,9 +36513,9 @@
       }
     },
     "@quintype/backend": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.1.tgz",
-      "integrity": "sha512-z6DVASwl+TwmTtrjqJ3G9fzakpjQaFiN74inKornAgHYlJgqP5+irgEUnmwCVg8a4UCCcWqAJams4bkA7qu2kQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@quintype/backend/-/backend-2.3.3.tgz",
+      "integrity": "sha512-tpzH5gzBvPDCK03yX0uZoHF5s/ZX6JehW9Y+xA2O0bMX88kRPtB2weu/tv7sp+vuaoU/SjgK6owHNDC/EQcXZw==",
       "requires": {
         "axios": "^0.21.1",
         "bluebird": "^3.7.2",
@@ -36565,11 +36531,6 @@
           "requires": {
             "follow-redirects": "^1.14.0"
           }
-        },
-        "follow-redirects": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-          "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
         }
       }
     },
@@ -36760,12 +36721,11 @@
       }
     },
     "@quintype/components": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.0.2.tgz",
-      "integrity": "sha512-QhfDexSof8oU3yenG9m4SB9qKuph/qKTtz7a2dDroPDKecul/Ig/jrwRNiOpZd/Mcicwyhb2LMigIoaJf0OmWw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-3.3.3.tgz",
+      "integrity": "sha512-a1XfNBICVtPq1h3ATr37asjeF/jI2j+rwhtrw5uV+YBSH9dXjZ3L/WjH+/T066Dt+EgfGjUkczXUwdRF6YBxmA==",
       "requires": {
         "@babel/runtime": "^7.16.3",
-        "atob": "^2.1.2",
         "classnames": "^2.3.1",
         "empty-web-gif": "^1.0.1",
         "get-video-id": "^3.4.3",
@@ -36806,14 +36766,14 @@
       }
     },
     "@quintype/framework": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.7.7.tgz",
-      "integrity": "sha512-FGIkT2PVdJBR5UbarU97kArIZBfOMUiHugELGscxM6R3yzUrP0wEzzLmqhu9caWWJ2ZD/ThFaE2E3dUhRYViXQ==",
+      "version": "7.19.9-amp-focus-point.2",
+      "resolved": "https://registry.npmjs.org/@quintype/framework/-/framework-7.19.9-amp-focus-point.2.tgz",
+      "integrity": "sha512-++CFanAA9jH5LLAQt6LBvHkuhY58JbJMq62jIL7MvEIzCjCanRoAhUKwOypNvn0AfJmYYznCjxm8gHhoI8mbzg==",
       "requires": {
         "@ampproject/toolbox-optimizer": "2.8.3",
-        "@quintype/amp": "^2.4.28",
-        "@quintype/backend": "^2.3.1",
-        "@quintype/components": "^3.0.0",
+        "@quintype/amp": "^2.14.1-amp-focus-point.0",
+        "@quintype/backend": "^2.3.3",
+        "@quintype/components": "^3.3.0",
         "@quintype/prerender-node": "^3.2.26",
         "@quintype/seo": "^1.39.0",
         "atob": "^2.1.2",
@@ -38246,6 +38206,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "atob-utf-8": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/atob-utf-8/-/atob-utf-8-1.0.4.tgz",
+      "integrity": "sha512-URuOY6Qtmeu51HqXgIO/osI2MAY6kiJ5WwXMo3hqTlaGn28AexlyPvJFy5fsfcpc3EgnglbaHkkDZ5ibFKWLww=="
+    },
     "autocompleter": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/autocompleter/-/autocompleter-6.1.2.tgz",
@@ -38300,13 +38265,6 @@
       "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
         "follow-redirects": "^1.14.4"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.14.5",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-          "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
-        }
       }
     },
     "babel-code-frame": {
@@ -38622,15 +38580,15 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.3.tgz",
+      "integrity": "sha512-jBioLwBVHpOMU4NsueH/ADcHrjS0Y/WTpt2eGVmmuSFNEv2DF3XhcMncuZlbbjxQ4vzxg+yEr6E6TNjrIQbsJQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.21.4",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -39451,9 +39409,9 @@
       }
     },
     "camelize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -40605,9 +40563,9 @@
       }
     },
     "css-to-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
-      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -43212,22 +43170,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fontfaceobserver": {
       "version": "2.1.0",
@@ -49807,9 +49752,9 @@
       "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -54264,7 +54209,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -54608,9 +54553,9 @@
       "dev": true
     },
     "styled-components": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
-      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@loadable/server": "^5.14.2",
     "@quintype/bridgekeeper-js": "^2.8.2-feature-otp.1",
     "@quintype/components": "^3.0.2",
-    "@quintype/framework": "^7.19.9-amp-focus-point.2",
+    "@quintype/framework": "^7.19.11",
     "@quintype/seo": "^1.42.1",
     "axios": "^0.24.0",
     "fontfaceobserver": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@loadable/server": "^5.14.2",
     "@quintype/bridgekeeper-js": "^2.8.2-feature-otp.1",
     "@quintype/components": "^3.0.2",
-    "@quintype/framework": "^7.7.7",
+    "@quintype/framework": "^7.19.9-amp-focus-point.2",
     "@quintype/seo": "^1.42.1",
     "axios": "^0.24.0",
     "fontfaceobserver": "^2.1.0",


### PR DESCRIPTION
Currently , if AspectRatio is not passed, under AMP stories, the image height is taken from metadata , not cropping as per focus point;

Fixes # (issue-reference)
https://github.com/quintype/ace-planning/issues/857

Dependencies # (dependency-issue-reference)
https://github.com/quintype/quintype-amp/pull/442
https://github.com/quintype/quintype-node-framework/pull/377
